### PR TITLE
unnecessary_file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+public/uploads/*
+.DS_Store

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,10 @@ Bundler.require(*Rails.groups)
 
 module FreemarketSample61f
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    config.generators do |g|
+      g.stylesheets false
+      g.javascripts false
+      g.helper false
+    end
   end
 end


### PR DESCRIPTION
# What
gitignoreとapplication.rbに生成して欲しくないファイルと不要なファイルを追記した。
※chat-spaceと異なる点・・・テストに関する記述はなしにした。

# Why
不要なファイルがあると編集もしづらく、他の人が見た時にアプリケーションの構成がわかりにくくなってしまうため。