### PR TITLE
README修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@
 |condition_id|integer|null:false, foreign_key: true|active_hashで管理、カラム名は任意でつける|
 |delivery_fee_burden_id|integer|null:false, foreign_key: true|active_hashで管理、カラム名は任意でつける|
 |delivery_method_id|integer|null:false, foreign_key: true|active_hashで管理、カラム名は任意でつける|
-|delivery_prefecture_id|integer|null:false, foreign_key: true|active_hashで管理、カラム名は任意でつける|
+|prefecture_id|integer|null:false, foreign_key: true|active_hashで管理、カラム名は任意でつける|
 |delivery_by_day_id|integer|null:false, foreign_key: true|active_hashで管理、カラム名は任意でつける|
 |user_id|references|null:false, foreign_key: true|　|
 |size_id|references|foreign_key: true|　|
@@ -113,7 +113,7 @@
 - belongs_to :size
 - has_one :trading_item, dependent: :destroy
 - has_one :finished_item, dependent: :destroy
-- has_many :images
+- has_many :images, dependent: :destroy_all
 - has_many: messages
 - has_many :likes
 
@@ -136,11 +136,19 @@
 - belongs_to :_display_item
 - has_many: trade_messages
 
+### _images_
+|カラム名|型|オプション|備考|
+|---|---|---|---|
+|image|string|null:false|　|
+|display_item_id|references|foreign_key: true|　|
+#### アソシエーション
+- belongs_to :_display_item
+
 ### _categories_
 |カラム名|型|オプション|備考|
 |---|---|---|---|
 |name|string|null: false|　|
-|path|string|　|gem'ancestry'を使用|
+|ancestry|string|　|gem'ancestry'を使用|
 |size_id|references|foreign_key: true|　|
 #### アソシエーション
 - has_many :display_items
@@ -150,7 +158,7 @@
 |カラム名|型|オプション|備考|
 |---|---|---|---|
 |size|string|null: false|　|
-|path|string|　|gem'ancestry'を使用|
+|ancestry|string|　|gem'ancestry'を使用|
 #### アソシエーション
 - has_many :display_items
 - has_many :categolies

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ReadMe
-![ER_free-marcket (2)](https://user-images.githubusercontent.com/12472994/67730003-cc0b9580-fa36-11e9-9314-b26b0a224b75.png)
+![ER_free-marcket (3)](https://user-images.githubusercontent.com/12472994/67822897-73a2c980-fb04-11e9-8e8f-4a6dea398e87.png)
 
 ## テーブル
 - users

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ReadMe
+# README
 ![ER_free-marcket (3)](https://user-images.githubusercontent.com/12472994/67822897-73a2c980-fb04-11e9-8e8f-4a6dea398e87.png)
 
 ## テーブル


### PR DESCRIPTION
# what
- 実際の実装に合わせて、カラム名等を修正

1. imagesテーブルが抜けていたので追加

1. dispaly_itemsのレコードを消した時に、関連するimagesのレコードを消すように修正

1. categoryとsizeのカラム名をpathからancestryに修正

1. display_itemsのカラム名をdelivery_prefecture_idからprefecture_idに修正
# why
- READMEを最新にするため