### PR TITLE
不要なfont-awesome系のgem削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,10 +59,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
 gem "haml-rails", ">= 1.0", '<= 2.0.1'
-
-gem "font-awesome-rails"
 gem 'devise'
 gem "haml-rails", ">= 1.0", '<= 2.0.1'
 gem 'erb2haml'
@@ -73,6 +70,5 @@ group :production do
 end
 gem 'carrierwave'
 gem 'fog-aws'
-gem 'font-awesome-sass'
 gem "font-awesome-rails"
 gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,8 +113,6 @@ GEM
       nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
-    font-awesome-sass (5.11.2)
-      sassc (>= 1.11)
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -233,8 +231,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.2.1)
-      ffi (~> 1.9)
     sexp_processor (4.13.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
@@ -294,7 +290,6 @@ DEPENDENCIES
   erb2haml
   fog-aws
   font-awesome-rails
-  font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,3 @@
-@import 'font-awesome-sprockets';
 @import 'font-awesome';
 @import "reset";
 @import "./display_items/new";


### PR DESCRIPTION
# what
- gem 'font-awesome-sass'を削除
# why
- デプロイで悪さをしてそうだったため