### PR TITLE
商品詳細ページの前後のアイテムリンクに対応、リンク時にjsが効くように修正

### DIFF
--- a/app/assets/javascripts/display_items_slide.js
+++ b/app/assets/javascripts/display_items_slide.js
@@ -3,40 +3,43 @@ $(function() {
   var check = /\/display_items\/[0-9]*/;
   if (check.test(path)) {
 
-    var slider = ".item__content__photo__slider"; // スライダー
-    var thumbnailItem = ".item__content__photo__thumb .thumbnail-item"; // サムネイル画像アイテム
-
-    // サムネイル画像アイテムに data-index でindex番号を付与
-    $(thumbnailItem).each(function(){
-      var index = $(thumbnailItem).index(this);
-      $(this).attr("data-index",index);
-    });
-    
-    // スライダー初期化後、カレントのサムネイル画像にクラス「thumbnail-current」を付ける
-    // 「slickスライダー作成」の前にこの記述は書いてください。
+    //初回読み込み、リロード、ページ切り替えで動く。
+    $(document).on('turbolinks:load', function() {
+      var slider = ".item__content__photo__slider"; // スライダー
+      var thumbnailItem = ".item__content__photo__thumb .thumbnail-item"; // サムネイル画像アイテム
   
-    $(slider).on('init',function(slick){
-      var index = $(".slide-item.slick-slide.slick-current").attr("data-slick-index");
-      $(thumbnailItem+'[data-index="'+index+'"]').addClass("thumbnail-current");
-    });
-  
-    //slickスライダー初期化  
-    $(slider).slick({
-      arrows: false,
-      infinite: false //これはつけましょう。
-    });
-    //サムネイル画像アイテムをクリックしたときにスライダー切り替え
-    $(thumbnailItem).on('click',function(){
-      var index = $(this).attr("data-index");
-      $(slider).slick("slickGoTo",index,false);
-    });
-    
-    //サムネイル画像のカレントを切り替え
-    $(slider).on('beforeChange',function(event,slick, currentSlide,nextSlide){
+      // サムネイル画像アイテムに data-index でindex番号を付与
       $(thumbnailItem).each(function(){
-        $(this).removeClass("thumbnail-current");
+        var index = $(thumbnailItem).index(this);
+        $(this).attr("data-index",index);
       });
-      $(thumbnailItem+'[data-index="'+nextSlide+'"]').addClass("thumbnail-current");
+      
+      // スライダー初期化後、カレントのサムネイル画像にクラス「thumbnail-current」を付ける
+      // 「slickスライダー作成」の前にこの記述は書いてください。
+    
+      $(slider).on('init',function(slick){
+        var index = $(".slide-item.slick-slide.slick-current").attr("data-slick-index");
+        $(thumbnailItem+'[data-index="'+index+'"]').addClass("thumbnail-current");
+      });
+    
+      //slickスライダー初期化  
+      $(slider).slick({
+        arrows: false,
+        infinite: false //これはつけましょう。
+      });
+      //サムネイル画像アイテムをクリックしたときにスライダー切り替え
+      $(thumbnailItem).on('click',function(){
+        var index = $(this).attr("data-index");
+        $(slider).slick("slickGoTo",index,false);
+      });
+      
+      //サムネイル画像のカレントを切り替え
+      $(slider).on('beforeChange',function(event,slick, currentSlide,nextSlide){
+        $(thumbnailItem).each(function(){
+          $(this).removeClass("thumbnail-current");
+        });
+        $(thumbnailItem+'[data-index="'+nextSlide+'"]').addClass("thumbnail-current");
+      });
     });
   }
 });

--- a/app/assets/javascripts/exhibit_brand.js
+++ b/app/assets/javascripts/exhibit_brand.js
@@ -8,39 +8,44 @@ $(function() {
     })
     return html;
   }
-  // ブランド検索機能
-  $(document).on('keyup', '#display_item_brand_id', function() {
-    // リストを空にする
-    $('.brand_search_result__box').children().remove();
-    // キーワード取得
-    var keyword = $('#display_item_brand_id').val();
-    // キーワードが空の時は何もしない
-    if ( keyword != "" ) {
-      $.ajax({
-        url: '/brands/search',
-        type: 'post',
-        data: {
-          keyword: keyword,
-        },
-        dataType: 'json',
-      })
-      .done(function(brands) {
-        var html = creat_html_list(brands)
-        $('.brand_search_result__box').append(html);
-      })
-      .fail(function() {
-        alert("ブランドの取得に失敗しました");
-      })
-    }
-  });
 
-  // ブランド選択機能
-  $(document).on('click', ".brand_search_result__box__content", function() {
-    // クリックされた要素の名前を取得
-    var text = this.innerText;
-    // 名前をinputに挿入
-    $("#display_item_brand_id").val(text);
-    // 検索リスト削除
-    $('.brand_search_result__box').children().remove();
+
+  //初回読み込み、リロード、ページ切り替えで動く。
+  $(document).on('turbolinks:load', function() {
+    // ブランド検索機能
+    $(document).on('keyup', '#display_item_brand_id', function() {
+      // リストを空にする
+      $('.brand_search_result__box').children().remove();
+      // キーワード取得
+      var keyword = $('#display_item_brand_id').val();
+      // キーワードが空の時は何もしない
+      if ( keyword != "" ) {
+        $.ajax({
+          url: '/brands/search',
+          type: 'post',
+          data: {
+            keyword: keyword,
+          },
+          dataType: 'json',
+        })
+        .done(function(brands) {
+          var html = creat_html_list(brands)
+          $('.brand_search_result__box').append(html);
+        })
+        .fail(function() {
+          alert("ブランドの取得に失敗しました");
+        })
+      }
+    });
+
+    // ブランド選択機能
+    $(document).on('click', ".brand_search_result__box__content", function() {
+      // クリックされた要素の名前を取得
+      var text = this.innerText;
+      // 名前をinputに挿入
+      $("#display_item_brand_id").val(text);
+      // 検索リスト削除
+      $('.brand_search_result__box').children().remove();
+    });
   });
 });

--- a/app/assets/javascripts/exhibit_category.js
+++ b/app/assets/javascripts/exhibit_category.js
@@ -147,75 +147,78 @@ $(function() {
   }
 
 
-  // カテゴリ1のイベント発火
-  $('#display_item_category_id').on('change', function() {
-    var category_id = $('#display_item_category_id').val();
-    $.ajax({
-      url: '/categories/search_level1',
-      type: 'post',
-      data: {
-        category_id: category_id
-      },
-      dataType: 'json',
-    })
-    .done(function(categories) {
-      // Add1とAdd2のセレクトボックスを削除
-      $('.content__form__Add1').remove();
-      $('.content__form__Add2').remove();
-      // sizeのセレクトボックス削除
-      $('.select_size').children().remove();
-      if ( categories.length >= 1 ) {
-        // 選択に応じたセレクトボックス作成
-        var html = creat_html_select_category_lv2(categories)
-        $('.select_category').append(html);
-      }
-    })
-    .fail(function() {
-      alert('カテゴリの取得に失敗しました');
-    })
-    var category_id = $('#display_item_category_id').val();
-    create_html_size_and_brand(category_id);
-  });
+  //初回読み込み、リロード、ページ切り替えで動く。
+  $(document).on('turbolinks:load', function() {
+    // カテゴリ1のイベント発火
+    $('#display_item_category_id').on('change', function() {
+      var category_id = $('#display_item_category_id').val();
+      $.ajax({
+        url: '/categories/search_level1',
+        type: 'post',
+        data: {
+          category_id: category_id
+        },
+        dataType: 'json',
+      })
+      .done(function(categories) {
+        // Add1とAdd2のセレクトボックスを削除
+        $('.content__form__Add1').remove();
+        $('.content__form__Add2').remove();
+        // sizeのセレクトボックス削除
+        $('.select_size').children().remove();
+        if ( categories.length >= 1 ) {
+          // 選択に応じたセレクトボックス作成
+          var html = creat_html_select_category_lv2(categories)
+          $('.select_category').append(html);
+        }
+      })
+      .fail(function() {
+        alert('カテゴリの取得に失敗しました');
+      })
+      var category_id = $('#display_item_category_id').val();
+      create_html_size_and_brand(category_id);
+    });
 
 
-  // カテゴリ2のイベント発火
-  $(document).on('change', '#display_item_category2_id', function() {
-    // カテゴリ1の入力値取得
-    var category_id = $('#display_item_category_id').val();
-    // カテゴリ2の入力値取得
-    var category2_id = $('#display_item_category2_id').val();
-    $.ajax({
-      url: '/categories/search_level2',
-      type: 'post',
-      data: {
-        category_id: category_id,
-        category2_id: category2_id
-      },
-      dataType: 'json',
-    })
-    .done(function(categories) {
-      // Add2セレクトボックスを削除
-      $('.content__form__Add2').remove();
-      // sizeのセレクトボックス削除
-      $('.select_size').children().remove();
-      // 要素が１個以上あれば生成
-      if (categories.length >= 1 ) {
-        // 選択に応じたセレクトボックス作成
-        var html = creat_html_select_category_lv3(categories)
-        $('.select_category').append(html);
-      } 
-    })
-    .fail(function() {
-      alert('カテゴリの取得に失敗しました');
-    })
-    var category_id = $('#display_item_category2_id').val();
-    create_html_size_and_brand(category_id);
-  });
+    // カテゴリ2のイベント発火
+    $(document).on('change', '#display_item_category2_id', function() {
+      // カテゴリ1の入力値取得
+      var category_id = $('#display_item_category_id').val();
+      // カテゴリ2の入力値取得
+      var category2_id = $('#display_item_category2_id').val();
+      $.ajax({
+        url: '/categories/search_level2',
+        type: 'post',
+        data: {
+          category_id: category_id,
+          category2_id: category2_id
+        },
+        dataType: 'json',
+      })
+      .done(function(categories) {
+        // Add2セレクトボックスを削除
+        $('.content__form__Add2').remove();
+        // sizeのセレクトボックス削除
+        $('.select_size').children().remove();
+        // 要素が１個以上あれば生成
+        if (categories.length >= 1 ) {
+          // 選択に応じたセレクトボックス作成
+          var html = creat_html_select_category_lv3(categories)
+          $('.select_category').append(html);
+        } 
+      })
+      .fail(function() {
+        alert('カテゴリの取得に失敗しました');
+      })
+      var category_id = $('#display_item_category2_id').val();
+      create_html_size_and_brand(category_id);
+    });
 
 
-  // カテゴリ3のイベント発火
-  $(document).on('change', '#display_item_category3_id', function() {
-     var category_id = $('#display_item_category3_id').val();
-     create_html_size_and_brand(category_id);
+    // カテゴリ3のイベント発火
+    $(document).on('change', '#display_item_category3_id', function() {
+      var category_id = $('#display_item_category3_id').val();
+      create_html_size_and_brand(category_id);
+    });
   });
 });

--- a/app/assets/javascripts/exhibit_delivery_method.js
+++ b/app/assets/javascripts/exhibit_delivery_method.js
@@ -25,29 +25,32 @@ $(function() {
     return html;
   }
 
-  $('#display_item_delivery_fee_burden_id').on("change", function() {
-    // 配送方法を削除
-    $('.select_delivery_method').children().remove();
-    var burden_id = $('#display_item_delivery_fee_burden_id').val();
-    // --が選択されたら配送方法を削除
-    if ( burden_id == "" ) {
+  //初回読み込み、リロード、ページ切り替えで動く。
+  $(document).on('turbolinks:load', function() {
+    $('#display_item_delivery_fee_burden_id').on("change", function() {
+      // 配送方法を削除
       $('.select_delivery_method').children().remove();
-    } else {
-      $.ajax({
-        url: '/delivery_methods/search',
-        type: 'post',
-        data: {
-          burden_id: burden_id,
-        },
-        dataType: 'json',
-      })
-      .done(function(methods) {
-        var html = create_html_select_method(methods);
-        $('.select_delivery_method').append(html);
-      })
-      .fail(function() {
-        alert("配送方法の取得に失敗しました");
-      })
-    }
+      var burden_id = $('#display_item_delivery_fee_burden_id').val();
+      // --が選択されたら配送方法を削除
+      if ( burden_id == "" ) {
+        $('.select_delivery_method').children().remove();
+      } else {
+        $.ajax({
+          url: '/delivery_methods/search',
+          type: 'post',
+          data: {
+            burden_id: burden_id,
+          },
+          dataType: 'json',
+        })
+        .done(function(methods) {
+          var html = create_html_select_method(methods);
+          $('.select_delivery_method').append(html);
+        })
+        .fail(function() {
+          alert("配送方法の取得に失敗しました");
+        })
+      }
+    });
   });
 });

--- a/app/assets/javascripts/exhibit_price.js
+++ b/app/assets/javascripts/exhibit_price.js
@@ -39,28 +39,30 @@ $(function() {
     $('.content__form__list-C').append(html);
   }
 
+  //初回読み込み、リロード、ページ切り替えで動く。
+  $(document).on('turbolinks:load', function() {
+    $('#display_item_price').on('keyup', function() {
 
-  $('#display_item_price').on('keyup', function() {
-
-    var price = $('#display_item_price').val();
-
-    // 表示切り替えエリアをリセット
-    remove_html_price_area()
-
-    // 入力値に応じて、処理を切り替え
-    if ( price >= 300 && price <= 9999999 ) {
-      var commission_rate = calc_commission_rate(price)
-      var sales = calc_sales(price)
-
-      // 手数料のビューを取り付け
-      create_html_commission_rate_after_append(commission_rate)
-      // 売上のビューを取り付け
-      create_html_sales_after_append(sales)
-    } else {
-      // 手数料のビューを取り付け
-      create_html_commission_rate_after_append("-")
-      // 売上のビューを取り付け
-      create_html_sales_after_append("-")
-    }
+      var price = $('#display_item_price').val();
+  
+      // 表示切り替えエリアをリセット
+      remove_html_price_area()
+  
+      // 入力値に応じて、処理を切り替え
+      if ( price >= 300 && price <= 9999999 ) {
+        var commission_rate = calc_commission_rate(price)
+        var sales = calc_sales(price)
+  
+        // 手数料のビューを取り付け
+        create_html_commission_rate_after_append(commission_rate)
+        // 売上のビューを取り付け
+        create_html_sales_after_append(sales)
+      } else {
+        // 手数料のビューを取り付け
+        create_html_commission_rate_after_append("-")
+        // 売上のビューを取り付け
+        create_html_sales_after_append("-")
+      }
+    });
   });
 });

--- a/app/assets/stylesheets/display_items/_show.scss
+++ b/app/assets/stylesheets/display_items/_show.scss
@@ -445,7 +445,38 @@
 }
 
 
-
+.navi {
+  background: #f5f5f5;
+  position: relative;
+  border-top: 1px solid #eee;
+  &__box {
+    width: 1020px;
+    overflow: visible;
+    margin: 0 auto;
+    padding: 16px 0;
+    white-space: normal;
+    &__list {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      display: inline-block;
+      font-size: 14px;
+      line-height: 1.2;
+      &__link {
+        margin-right: 10px;
+        color: #333;
+        &:hover {
+          color: rgba(#333, 0.5);
+          text-decoration-line: underline;
+        }
+      }
+      &__link-right {
+        margin-left: 10px;
+        color: #333;
+        font-weight: bold;
+      }
+    }
+  }
+}
 
 
 

--- a/app/models/display_item.rb
+++ b/app/models/display_item.rb
@@ -15,4 +15,12 @@ class DisplayItem < ApplicationRecord
   has_many :comments, dependent: :delete_all
 
   accepts_nested_attributes_for :images
+
+  def previous
+    DisplayItem.where("id < ?", self.id).order("id DESC").first
+  end
+
+  def next
+    DisplayItem.where("id > ?", self.id).order("id ASC").first
+  end
 end

--- a/app/views/display_items/show.html.haml
+++ b/app/views/display_items/show.html.haml
@@ -243,6 +243,15 @@
       .other-items__box.clearfix
         = render partial: "./shared/display_items", locals: {items: @same_category_items}
 
+.navi
+  %ul.navi__box
+    %li.navi__box__list
+      = link_to root_path, class: "navi__box__list__link" do
+        メルカリ
+      = fa_icon "chevron-right"
+    %li.navi__box__list
+      %span.navi__box__list__link-right
+        = @display_item.name
 
 = render 'shared/aside'
 = render 'shared/footer'

--- a/app/views/display_items/show.html.haml
+++ b/app/views/display_items/show.html.haml
@@ -193,16 +193,18 @@
         = f.submit "コメントする", class: "message__content__form__submit"
 
 %ul.navi-link.clearfix
-  %li.navi-link__prev
-    = link_to "#", class: "navi-link__link" do
-      = fa_icon "angle-left", class: "icon icon__prev"
-      %span
-        一つ前のアイテム名を出す
-  %li.navi-link__next
-    = link_to "#", class: "navi-link__link" do
-      %span
-        一つ先のアイテム名を出す
-      = fa_icon "angle-right", class: "icon icon__next"
+  - if @display_item.previous.present?
+    %li.navi-link__prev
+      = link_to display_item_path(@display_item.previous.id), class: "navi-link__link" do
+        = fa_icon "angle-left", class: "icon icon__prev"
+        %span
+          = @display_item.previous.name
+  - if @display_item.next.present?
+    %li.navi-link__next
+      = link_to display_item_path(@display_item.next.id), class: "navi-link__link" do
+        %span
+          = @display_item.next.name
+        = fa_icon "angle-right", class: "icon icon__next"
 
 
 .media


### PR DESCRIPTION
# what
- 商品詳細ページに前後のアイテムリンクを追加
- 商品詳細ページ下部のパンくずもどきに対応
- ついでにリンク時にjsが効かなくなる件を修正
# why
- 詳細ページ完成のため
- jsが効かなくなると不便なので修正