### PR TITLE
マイグレーションファイル修正、最初の歴史がgive_nameになっていたので直した

### DIFF
--- a/db/migrate/20191027072255_create_user_profiles.rb
+++ b/db/migrate/20191027072255_create_user_profiles.rb
@@ -3,9 +3,9 @@ class CreateUserProfiles < ActiveRecord::Migration[5.0]
     create_table :user_profiles do |t|
       t.references  :user,                   foreign_key: true
       t.string      :family_name,            null: false
-      t.string      :given_name,              null: false
+      t.string      :last_name,              null: false
       t.string      :family_name_kana,       null: false
-      t.string      :given_name_kana,         null: false
+      t.string      :last_name_kana,         null: false
       t.text        :introduction
       t.integer     :birth_year,             null: false
       t.integer     :birth_month,            null: false


### PR DESCRIPTION
# what
- user_profilesを作成するマイグレーションファイルを修正
- last_nameがgiven_nameになっていたので、それより後のmigrateで失敗する（last_nameをgiven_nameに変更するmigrateでこけている
# why
- 不具合修正