### PR TITLE
出品停止状態を実装

### DIFF
--- a/app/assets/stylesheets/_mypages.scss
+++ b/app/assets/stylesheets/_mypages.scss
@@ -285,8 +285,18 @@
           font-size: 16px;
           color: #888;
         }
-        &__status {
+        &__status-selling {
           background: #0099e8;
+          display: inline-block;
+          margin: 8px 0 0 0;
+          padding: 5px 6px;
+          border-radius: 2px;
+          font-size: 12px;
+          color: #fff;
+          font-weight: bold;
+        }
+        &__status-stopping {
+          background: #ea352d;
           display: inline-block;
           margin: 8px 0 0 0;
           padding: 5px 6px;

--- a/app/assets/stylesheets/display_items/_show.scss
+++ b/app/assets/stylesheets/display_items/_show.scss
@@ -691,3 +691,18 @@
   -moz-osx-font-smoothing: grayscale;
   color: #ccc;
 }
+// フラッシュメッセージ
+.notifications > .notice {
+  width: 100%;
+  height: 40px;
+  line-height: 40px;
+  text-align: center;
+  background: rgb(180, 255, 90);
+}
+.notifications > .alert {
+  width: 100%;
+  height: 40px;
+  line-height: 40px;
+  text-align: center;
+  background: rgb(250, 80, 30);
+}

--- a/app/assets/stylesheets/display_items/_show.scss
+++ b/app/assets/stylesheets/display_items/_show.scss
@@ -311,7 +311,7 @@
 
 
 .navi-link {
-  margin: 24px auto 0;
+  margin: 24px auto;
   width: 700px;
   &__prev {
     width: 45%;

--- a/app/assets/stylesheets/display_items/_show.scss
+++ b/app/assets/stylesheets/display_items/_show.scss
@@ -531,6 +531,18 @@
     font-size: 16px;
     text-align: center;
   }
+  &__restart {
+    margin: 16px 0 16px 0;
+    background: rgb(25, 80, 170);
+    border: 1px solid rgb(25, 80, 170);
+    color: #fff;
+    display: block;
+    width: 100%;
+    line-height: 48px;
+    font-size: 14px;
+    transition: all ease-out .3s;
+    text-align: center;
+  }
   &__stop {
     margin: 16px 0 16px 0;
     background: #aaa;

--- a/app/controllers/display_items_controller.rb
+++ b/app/controllers/display_items_controller.rb
@@ -3,7 +3,19 @@ class DisplayItemsController < ApplicationController
   require "date"
 
   def index
-    @display_items = DisplayItem.limit(10).order(id: "DESC")
+    @find_items = DisplayItem.order(id: "DESC")
+    @display_items = []
+
+    @find_items.each do |item|
+      if @display_items.length < 11
+        unless item.stopping_item
+          @display_items << item
+        end
+      else
+        break
+      end
+    end
+
     # カテゴリーを取得
     @categories = Category.where(ancestry: nil)
     

--- a/app/controllers/stopping_items_controller.rb
+++ b/app/controllers/stopping_items_controller.rb
@@ -1,0 +1,19 @@
+class StoppingItemsController < ApplicationController
+
+  def create
+    @stopping_item = StoppingItem.new(display_item_id: params[:format])
+    if @stopping_item.save
+      redirect_to display_items_mypages_path
+    else
+    end
+  end
+
+  def destroy
+    @stopping_item = StoppingItem.find_by(display_item_id: params[:id])
+    if @stopping_item.destroy
+      redirect_to display_items_mypages_path
+    else
+    end
+  end
+
+end

--- a/app/controllers/stopping_items_controller.rb
+++ b/app/controllers/stopping_items_controller.rb
@@ -3,16 +3,18 @@ class StoppingItemsController < ApplicationController
   def create
     @stopping_item = StoppingItem.new(display_item_id: params[:format])
     if @stopping_item.save
-      redirect_to display_items_mypages_path
+      redirect_to display_item_path(params[:format]), notice: '出品を停止しました'
     else
+      redirect_to display_item_path(params[:format]), alert: '出品の停止に失敗しました'
     end
   end
 
   def destroy
     @stopping_item = StoppingItem.find_by(display_item_id: params[:id])
     if @stopping_item.destroy
-      redirect_to display_items_mypages_path
+      redirect_to display_item_path(params[:id]), notice: '出品を再開しました'
     else
+      redirect_to display_item_path(params[:id]), alert: '出品の再開に失敗しました'
     end
   end
 

--- a/app/models/display_item.rb
+++ b/app/models/display_item.rb
@@ -30,6 +30,7 @@ class DisplayItem < ApplicationRecord
   has_many :comments, dependent: :delete_all
 
   has_one :trading_item, dependent: :destroy
+  has_one :stopping_item, dependent: :destroy
 
   accepts_nested_attributes_for :images
 

--- a/app/models/stopping_item.rb
+++ b/app/models/stopping_item.rb
@@ -1,2 +1,3 @@
 class StoppingItem < ApplicationRecord
+  belongs_to :display_item
 end

--- a/app/views/display_items/show.html.haml
+++ b/app/views/display_items/show.html.haml
@@ -137,9 +137,10 @@
         %span.item__btn__impossible
           売り切れました
   - else
-    .item__btn
-      = link_to buy_display_item_path(@display_item.id), class: "item__btn__possible" do
-        購入画面に進む
+    - if @display_item.user_id != current_user.id
+      .item__btn
+        = link_to buy_display_item_path(@display_item.id), class: "item__btn__possible" do
+          購入画面に進む
 
 
   .item__description
@@ -167,7 +168,7 @@
         %span.item__footer__right__safe__text
           あんしん・あんぜんへの取り組み
 
-- if @display_item == current_user.id
+- if @display_item.user_id == current_user.id
   .item-change
     = link_to mypages_path, class: "item-change__edit" do
       商品の編集
@@ -197,22 +198,23 @@
         - else
           = f.text_area :comment, class: "message__content__form__text-field"
           = f.submit "コメントする", class: "message__content__form__submit"
-
-%ul.navi-link.clearfix
-  - if @display_item.previous.present?
-    %li.navi-link__prev
-      = link_to display_item_path(@display_item.previous.id), class: "navi-link__link" do
-        = fa_icon "angle-left", class: "icon icon__prev"
-        %span
-          = @display_item.previous.name
-  - if @display_item.next.present?
-    %li.navi-link__next
-      = link_to display_item_path(@display_item.next.id), class: "navi-link__link" do
-        %span
-          = @display_item.next.name
-        = fa_icon "angle-right", class: "icon icon__next"
+// 他人が出品した商品で表示する
+- if @display_item.user_id != current_user.id
+  %ul.navi-link.clearfix
+    - if @display_item.previous.present?
+      %li.navi-link__prev
+        = link_to display_item_path(@display_item.previous.id), class: "navi-link__link" do
+          = fa_icon "angle-left", class: "icon icon__prev"
+          %span
+            = @display_item.previous.name
+    - if @display_item.next.present?
+      %li.navi-link__next
+        = link_to display_item_path(@display_item.next.id), class: "navi-link__link" do
+          %span
+            = @display_item.next.name
+          = fa_icon "angle-right", class: "icon icon__next"
         
-// 自分が出品していない商品の場合は表示しない
+// 他人が出品した商品で表示する
 - if @display_item.user_id != current_user.id
   .media
     .media_text
@@ -230,7 +232,7 @@
           %span.media__box__ele__box.media-pinterest
             = fa_icon "pinterest ", class: "media-icon"
             
-// 自分が出品していない商品の場合は表示しない
+// 他人が出品した商品で表示する
 - if @display_item.user_id != current_user.id
   .other-items.clearfix
     - unless @mine_items.length == 0
@@ -251,16 +253,17 @@
               = @category_lv1.name + "（#{@category_lv2.name}）その他の商品"
         .other-items__box.clearfix
           = render partial: "./shared/display_items", locals: {items: @same_category_items}
-
-  .navi
-    %ul.navi__box
-      %li.navi__box__list
-        = link_to root_path, class: "navi__box__list__link" do
-          メルカリ
-        = fa_icon "chevron-right"
-      %li.navi__box__list
-        %span.navi__box__list__link-right
-          = @display_item.name
+  // 他人が出品した商品で表示する
+  - if @display_item.user_id != current_user.id
+    .navi
+      %ul.navi__box
+        %li.navi__box__list
+          = link_to root_path, class: "navi__box__list__link" do
+            メルカリ
+          = fa_icon "chevron-right"
+        %li.navi__box__list
+          %span.navi__box__list__link-right
+            = @display_item.name
 
 = render 'shared/aside'
 = render 'shared/footer'

--- a/app/views/display_items/show.html.haml
+++ b/app/views/display_items/show.html.haml
@@ -1,11 +1,10 @@
 = render 'shared/header'
+= render 'shared/flash'
 
 .item
 
-
   .item__title
     = @display_item.name
-
 
   .item__content.clearfix
     // 売切アイコン
@@ -26,7 +25,6 @@
         - @display_item.images.each do |image|
           %li.thumbnail-item
             = image_tag image.image.url
-
 
 
     %table.item__content__table

--- a/app/views/display_items/show.html.haml
+++ b/app/views/display_items/show.html.haml
@@ -173,8 +173,12 @@
     = link_to mypages_path, class: "item-change__edit" do
       商品の編集
     %p or
-    = link_to mypages_path, class: "item-change__stop" do
-      出品を一旦停止する
+    - if @display_item.stopping_item
+      = link_to stopping_item_path(@display_item.id), method: :delete, data: { confirm: '出品を再開しますか？' }, class: "item-change__restart" do
+        出品を再開する
+    - else
+      = link_to stopping_items_path(@display_item.id), method: :post, data: { confirm: '出品を停止しますか？' }, class: "item-change__stop" do
+        出品を一旦停止する
     = link_to display_item_path(@display_item.id), method: :delete, data: { confirm: '削除しますか？' }, class: "item-change__delete" do
       この商品を削除する
 

--- a/app/views/mypages/display_items.html.haml
+++ b/app/views/mypages/display_items.html.haml
@@ -44,9 +44,14 @@
                       =fa_icon "comment",class: 'exhibit-item__tab-content__lists__icons__comment'
                       %span
                         0
-                    .exhibit-item__tab-content__lists__icons__status
-                      出品中
-                    = fa_icon "angle-right", class: "exhibit-item__tab-content__lists__icons__right"
+                    - if display_item.stopping_item
+                      .exhibit-item__tab-content__lists__icons__status-stopping
+                        出品停止中
+                      = fa_icon "angle-right", class: "exhibit-item__tab-content__lists__icons__right"
+                    - else
+                      .exhibit-item__tab-content__lists__icons__status-selling
+                        出品中
+                      = fa_icon "angle-right", class: "exhibit-item__tab-content__lists__icons__right"
 
 
 = render 'shared/sell-icon'

--- a/app/views/shared/_flash.html.haml
+++ b/app/views/shared/_flash.html.haml
@@ -1,0 +1,3 @@
+.notifications
+  - flash.each do |key, value|
+    = content_tag(:div, value, class: key)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,8 @@ Rails.application.routes.draw do
   end
   # 取引中-商品のルーティング
   resources :trading_items, only: [:create]
+  # 出品停止中-商品のルーティング
+  resources :stopping_items, only: [:create, :destroy]
 
 
   # カテゴリのルーティング

--- a/test/controllers/stopping_items_controller_test.rb
+++ b/test/controllers/stopping_items_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class StoppingItemsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# what
- 商品の出品停止状態を実装
- 出品再開にもできるように実装
- 状態に応じて商品詳細画面とマイページ＞自分が出品したアイテム確認画面が変わる
- トップページに並ぶアイテムを出品中アイテムのみに変更

# why
- 商品の状態管理のため