### PR TITLE
トップページにカテゴリに一致するアイテムを表示する実装、及びビューにカテゴリ一覧を表示

### DIFF
--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -313,6 +313,21 @@
       line-height: 1.4em;
       margin: 0;
       padding: 0;
+      &__categories {
+        display: flex;
+        justify-content: center;
+        width: 100%;
+        font-size: 14px;
+        margin: 15px auto 0;
+        &__list {
+          margin: 0 15px 0 0;
+          padding: 8px 14px;
+          font-size: 15px;
+          font-weight: bold;
+          background: rgb(239, 239, 239);
+          border-radius: 15px;
+        }
+      }
     }
     &__tagspace{
       overflow-x: auto;
@@ -320,7 +335,7 @@
       white-space: nowrap;
       &__tag{
         display: flex;
-        margin: 0px auto;
+        margin: 0 auto;
         &__1{
           background-color: rgb(239, 239, 239);
           cursor: pointer;

--- a/app/controllers/display_items_controller.rb
+++ b/app/controllers/display_items_controller.rb
@@ -20,13 +20,13 @@ class DisplayItemsController < ApplicationController
     @hobies = []
 
     @items.each do |item|
-      if item.category.parent.parent_id == @lady.id && @ladies.length <= 10
+      if item.category.parent.parent_id == @lady.id && @ladies.length < 10
         @ladies << item
-      elsif item.category.parent.parent_id == @man.id && @mens.length <= 10
+      elsif item.category.parent.parent_id == @man.id && @mens.length < 10
         @mens << item
-      elsif item.category.parent.parent_id == @electrical.id && @electricals.length <= 10
+      elsif item.category.parent.parent_id == @electrical.id && @electricals.length < 10
         @electricals << item
-      elsif item.category.parent.parent_id == @hobby.id && @hobies.length <= 10
+      elsif item.category.parent.parent_id == @hobby.id && @hobies.length < 10
         @hobies << item
       elsif @ladies == 10 && @mens == 10 && @electricals == 10 && @hobies == 10
         break

--- a/app/controllers/display_items_controller.rb
+++ b/app/controllers/display_items_controller.rb
@@ -28,7 +28,7 @@ class DisplayItemsController < ApplicationController
         @electricals << item
       elsif item.category.parent.parent_id == @hobby.id && @hobies.length <= 10
         @hobies << item
-      elsif @ladies == 10 && @mens == 10 && @hobies == 10
+      elsif @ladies == 10 && @mens == 10 && @electricals == 10 && @hobies == 10
         break
       end
     end

--- a/app/controllers/display_items_controller.rb
+++ b/app/controllers/display_items_controller.rb
@@ -4,19 +4,36 @@ class DisplayItemsController < ApplicationController
   require "date"
 
   def index
-    @find_items = DisplayItem.order(id: "DESC")
-    @display_items = []
-    @find_items.each do |item|
-      if @display_items.length < 10
-        unless item.stopping_item
-          @display_items << item
-        end
-      else
+    # カテゴリーを取得
+    @lady = Category.find_by(name: "レディース")
+    @man = Category.find_by(name: "メンズ")
+    @electrical = Category.find_by(name: "家電・スマホ・カメラ")
+    @hobby = Category.find_by(name: "おもちゃ・ホビー・グッズ")
+ 
+    # カテゴリをまとめて配列に保存
+    @categories = [@lady, @man, @electrical, @hobby]
+
+    @items = DisplayItem.order('created_at DESC')
+    @ladies = []
+    @mens = []
+    @electricals = []
+    @hobies = []
+
+    @items.each do |item|
+      if item.category.parent.parent_id == @lady.id && @ladies.length <= 10
+        @ladies << item
+      elsif item.category.parent.parent_id == @man.id && @mens.length <= 10
+        @mens << item
+      elsif item.category.parent.parent_id == @electrical.id && @electricals.length <= 10
+        @electricals << item
+      elsif item.category.parent.parent_id == @hobby.id && @hobies.length <= 10
+        @hobies << item
+      elsif @ladies == 10 && @mens == 10 && @hobies == 10
         break
       end
     end
-    # カテゴリーを取得
-    @categories = Category.where(ancestry: nil)
+
+
   end
 
   def new

--- a/app/views/display_items/index.html.haml
+++ b/app/views/display_items/index.html.haml
@@ -17,7 +17,18 @@
         =image_tag "slidephone.png",class:'image-4'
 
   .main-content__itemslist
-    .main-content__itemslist__text 全ての商品の一覧
+    .main-content__itemslist__text
+      人気のカテゴリー
+    %ul.main-content__itemslist__text__categories
+      %li.main-content__itemslist__text__categories__list
+        レディース
+      %li.main-content__itemslist__text__categories__list
+        メンズ
+      %li.main-content__itemslist__text__categories__list
+        家電・スマホ・カメラ
+      %li.main-content__itemslist__text__categories__list
+        おもちゃ・ホビー・グッズ
+
     .main-content__itemslist__tagspace
       .main-content__itemslist__tagspace__tag
         -# .main-content__itemslist__tagspace__tag__1 エンジニア

--- a/app/views/shared/_categories.html.haml
+++ b/app/views/shared/_categories.html.haml
@@ -2,7 +2,7 @@
   .main-content__items
     .main-content__items__title
       .main-content__items__title__text
-        = category.name
+        = category.name + "新着アイテム"
       .main-content__items__title__more 
         .main-content__items__title__more__text もっとみる
         =fa_icon "chevron-right",class: 'main-content__items__item__more__icon'     
@@ -10,4 +10,11 @@
       .main-content__items__item__content
         .main-content__items__item__content__box
           -# アイテムを描画
-          = render "shared/items"
+          - if category.name == "レディース"
+            = render partial: "shared/items", locals: { display_items: @ladies }
+          - elsif category.name == "メンズ"
+            = render partial: "shared/items", locals: { display_items: @mens }
+          - elsif category.name == "家電・スマホ・カメラ"
+            = render partial: "shared/items", locals: { display_items: @electricals }
+          - elsif category.name == "おもちゃ・ホビー・グッズ"
+            = render partial: "shared/items", locals: { display_items: @hobies }

--- a/app/views/shared/_items.html.haml
+++ b/app/views/shared/_items.html.haml
@@ -1,4 +1,4 @@
-- @display_items.each do |display_item|
+- display_items.each do |display_item|
   = link_to display_item_path(display_item[:id]), data:{turbolinks: "false"} do
     .main-content__items__item__content__box__2
       // 売り切れアイコン


### PR DESCRIPTION
# what
- トップページにカテゴリに一致するアイテムの最新10件を表示するように実装
- 表示するカテゴリは、「レディース、メンズ、家電、おもちゃ」に固定
- ビューに「人気のカテゴリー一覧」を追加
# why
- メルカリにより近づけるため