### PR TITLE
To-fix-facebook-callback-error

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,7 +3,7 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-  config.omniauth :facebook,ENV['FACEBOOK_APP_ID'],ENV['FACEBOOK_APP_SECRET'],callback_url: "CALLBACK_URL"
+  config.omniauth :facebook,ENV['FACEBOOK_APP_ID'],ENV['FACEBOOK_APP_SECRET']
   config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'],ENV['GOOGLE_CLIENT_SECRET']
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing


### PR DESCRIPTION
# what
Facebook認証の際にcallback_urlを指定しないようにする。
# why
Facebook認証の際にドメインエラーを解決のため。