### PR TITLE
To-make-year'snumber-reverse(SNS)

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -31,6 +31,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       nickname:              session[:user_attributes]["nickname"],
       email:                 session[:user_attributes]["email"]
     )
+    @years = Array.new((1900..2019).map{|y| [y,y]}.reverse)
   end
   
   def create

--- a/app/views/users/registrations/sns.html.haml
+++ b/app/views/users/registrations/sns.html.haml
@@ -64,7 +64,7 @@
             %span.required-icon
               必須
               %br
-            = f.select :birth_year,options_for_select(1900..2019),{ prompt: "--"},{class:'validate[required]',id:'timetextfield'}
+            = f.select :birth_year,options_for_select(@years),{ prompt: "--"},{class:'validate[required]',id:'timetextfield'}
             %span.timetext 
               年 
             = f.select :birth_month,options_for_select(1..12),{ prompt: "--"},{class:'validate[required]',id:'timetextfield'}


### PR DESCRIPTION
# what
SNS認証で会員情報の入力ページの生年月日において、年は最近の年から選択できるようにした。
# why
ユーザーが使いやすい環境を作成するため。